### PR TITLE
Made catch blank and added stricter reaction policies

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -62,8 +62,9 @@ client.on("message", (message) => {
             setKlaxon(message)
         } 
     } else processMessage(message);
-     if (message.content.toLowerCase().indexOf("cum") >= 0) {
-        message.react("😋").catch(()=>{message.channel.send("😋")});
+    // replace regex just removes non-alphanumeric and _
+    if (message.content.toLowerCase().replace(/[\W_]+/g, ' ').split(' ').includes("cum")) {
+        message.react("😋").catch();
     } 
     
 });


### PR DESCRIPTION
Catches don't need anything in js and it shouldn't be _more_ annoying to block the bot than not to. Also made it only activate when the word is said by itself so it doesn't come up during "serious" topics.